### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ If you like this project and find it useful, please consider giving it a star on
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.1] - 2024-12-02
+
+### Added
+
+- [edge]: Verified to work with Matterbridge edge (matter.js new API).
+- [plugin]: Refactor movement to support concurrent movements from all screens.
+- [plugin]: Refactor movement to show the movement on the controller (if it supports that) even for close and open commands.
+- [matter]: Added bridgedNode and powerSource device types to the cover.
+
+### Changed
+
+- [package]: Requires matterbridge 1.6.5.
+- [package]: Updated dependencies.
+
+### Fixed
+
+- [somfy]: Fixed stop sent when the target is fully open or fully closed.
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
+</a>
+
 ## [1.2.0] - 2024-12-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-somfy-tahoma",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Matterbridge somfy tahoma plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -130,7 +130,7 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
   override async onConfigure() {
     this.log.info('onConfigure called');
     if (!this.tahomaClient) {
-      this.log.error('TaHoma service not connected');
+      this.log.error('TaHoma service not created');
       return;
     }
 
@@ -148,7 +148,7 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
   override async onShutdown(reason?: string) {
     this.log.info('onShutdown called with reason:', reason ?? 'none');
     if (!this.tahomaClient) {
-      this.log.error('TaHoma service not connected');
+      this.log.error('TaHoma service not created');
     } else {
       this.tahomaClient.removeAllListeners();
     }


### PR DESCRIPTION
## [1.2.1] - 2024-12-02

### Added

- [edge]: Verified to work with Matterbridge edge (matter.js new API).
- [plugin]: Refactor movement to support concurrent movements from all screens.
- [plugin]: Refactor movement to show the movement on the controller (if it supports that) even for close and open commands.
- [matter]: Added bridgedNode and powerSource device types to the cover.

### Changed

- [package]: Requires matterbridge 1.6.5.
- [package]: Updated dependencies.

### Fixed

- [somfy]: Fixed stop sent when the target is fully open or fully closed.

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
</a>