### PR TITLE
test(closure): try the Matter 1.5 Closure device type for Tahoma covers

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -343,6 +343,8 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
         const cover = this.covers.get(device.label);
         if (!cover) return;
         cover.bridgedDevice.log.info(`Command ${ign}stop${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}. Status ${cover.movementStatus}`);
+        if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
+        cover.commandTimeout = undefined;
         clearInterval(cover.moveInterval);
         cover.moveInterval = undefined;
         if (cover.movementStatus !== ClosureControl.MainState.Stopped) {
@@ -354,7 +356,11 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
 
       liftPanel.addCommandHandler('ClosureDimension.setTarget', ({ request: { position } }) => {
         const cover = this.covers.get(device.label);
-        if (!cover || position === undefined || position === null) return;
+        if (!cover) return;
+        if (!isValidNumber(position, 0, 10000)) {
+          cover.bridgedDevice.log.warn(`Command setTarget called with unsupported position:${position}`);
+          return;
+        }
         if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
         // oxlint-disable-next-line typescript/no-misused-promises
         cover.commandTimeout = setTimeout(async () => {
@@ -441,7 +447,7 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
 
     const overallCurrentState = cover.bridgedDevice.getAttribute(ClosureControl, 'overallCurrentState', log);
     await cover.bridgedDevice.setAttribute(
-      ClosureControl.id,
+      ClosureControl,
       'overallCurrentState',
       {
         position: closureOverallPositionFromPercent(position),

--- a/src/module.ts
+++ b/src/module.ts
@@ -294,7 +294,9 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
       });
 
       const cover = new Closure(device.label, device.serialNumber, {
-        tagList: [getSemtag(ClosureTag.Covering), getSemtag(getCoveringTag(device))],
+        // Window openers (e.g. Velux roof windows) are a Closure in their own right (ClosureTag.Window), not a covering,
+        // so the ClosureCoveringTag material subtype only applies to actual coverings (blinds, shutters, awnings, ...).
+        tagList: device.definition.uiClass === 'Window' ? [getSemtag(ClosureTag.Window)] : [getSemtag(ClosureTag.Covering), getSemtag(getCoveringTag(device))],
       });
       cover.createDefaultBasicInformationClusterServer(device.label, device.serialNumber, 0xfff1, 'Somfy Tahoma', 0x8000, device.definition.uiClass);
       const liftPanel = cover.addPanel('Lift', [getSemtag(ClosurePanelTag.Lift)], 'lift');

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@
  * @description This file contains the class SomfyTahomaPlatform.
  * @author Luca Liguori
  * @created 2024-03-06
- * @version 1.4.2
+ * @version 1.7.0
  * @license Apache-2.0
  *
  * Copyright 2025, 2026, 2027 Luca Liguori.
@@ -24,26 +24,53 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { bridgedNode, MatterbridgeDynamicPlatform, MatterbridgeEndpoint, type PlatformConfig, type PlatformMatterbridge, powerSource, windowCovering } from 'matterbridge';
+import { getSemtag, MatterbridgeDynamicPlatform, type MatterbridgeEndpoint, type PlatformConfig, type PlatformMatterbridge } from 'matterbridge';
+import { Closure } from 'matterbridge/devices';
 import { type AnsiLogger, BLUE, CYAN, debugStringify, ign, nf, rs, stringify, YELLOW } from 'matterbridge/logger';
-import { Identify, WindowCovering } from 'matterbridge/matter/clusters';
+import { ClosureCoveringTag, ClosurePanelTag, ClosureTag } from 'matterbridge/matter';
+import { ClosureControl, ClosureDimension } from 'matterbridge/matter/clusters';
 import { inspectError, isValidNumber, isValidString } from 'matterbridge/utils';
 import { Action, Client, Command, type Device, Execution, type State } from 'overkiz-client';
 
 export type MovementDuration = Record<string, number>;
-export const Stopped = WindowCovering.MovementStatus.Stopped;
-export const Opening = WindowCovering.MovementStatus.Opening;
-export const Closing = WindowCovering.MovementStatus.Closing;
 export const WC_PERCENT100THS_MIN_OPEN = 0;
 export const WC_PERCENT100THS_MAX_CLOSED = 10000;
 
 interface Cover {
   tahomaDevice: Device;
-  bridgedDevice: MatterbridgeEndpoint;
+  bridgedDevice: Closure;
+  liftPanel: MatterbridgeEndpoint;
   movementDuration: number;
-  movementStatus: WindowCovering.MovementStatus;
+  movementStatus: ClosureControl.MainState;
   moveInterval?: NodeJS.Timeout;
   commandTimeout?: NodeJS.Timeout;
+}
+
+/**
+ * Maps a discovered TaHoma device's uiClass to the closest ClosureCoveringTag semantic tag, used to disambiguate
+ * the Closure endpoint (Application Cluster Specification § 24, ClosureCoveringTag namespace).
+ *
+ * @param {Device} device - The discovered TaHoma device.
+ * @returns {typeof ClosureCoveringTag.Shutter} The semantic tag describing the covering type.
+ */
+function getCoveringTag(device: Device): typeof ClosureCoveringTag.Shutter {
+  const uiClass = device.definition.uiClass;
+  if (uiClass === 'VenetianBlind' || uiClass === 'ExteriorVenetianBlind') return ClosureCoveringTag.Venetian;
+  if (uiClass === 'Awning' || uiClass === 'Pergola') return ClosureCoveringTag.Awning;
+  if (uiClass === 'Screen' || uiClass === 'ExteriorScreen') return ClosureCoveringTag.Blind;
+  return ClosureCoveringTag.Shutter; // Shutter, RollerShutter and any other supported uiClass
+}
+
+/**
+ * Resolves the coarse ClosureControl.CurrentPosition enum matching a Lift panel percent position.
+ *
+ * @param {number} percent - The Lift panel position, 0 (fully open) to 10000 (fully closed).
+ * @returns {ClosureControl.CurrentPosition} The coarse overall current position.
+ */
+function closureOverallPositionFromPercent(percent: number): ClosureControl.CurrentPosition {
+  if (percent <= WC_PERCENT100THS_MIN_OPEN) return ClosureControl.CurrentPosition.FullyOpened;
+  if (percent >= WC_PERCENT100THS_MAX_CLOSED) return ClosureControl.CurrentPosition.FullyClosed;
+  return ClosureControl.CurrentPosition.PartiallyOpened;
 }
 
 export type SomfyTahomaPlatformConfig = PlatformConfig & {
@@ -146,13 +173,12 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
     }
 
     // Set cover to target = current position and status to stopped (current position persists in the cluster)
-    for (const device of this.getDevices()) {
-      const cover = this.covers.get(device.deviceName ?? '');
-      const position = device.getAttribute(WindowCovering, 'currentPositionLiftPercent100ths', device.log);
-      cover?.bridgedDevice.log.info(
-        `Setting ${device.deviceName} target to ${CYAN}${isValidNumber(position, 0, 10000) ? position / 100 : 'unknown'} %${nf} position and status to stopped. Movement duration: ${CYAN}${cover?.movementDuration}${nf}`,
+    for (const cover of this.covers.values()) {
+      const position = cover.liftPanel.getAttribute(ClosureDimension, 'currentState', cover.bridgedDevice.log)?.position;
+      cover.bridgedDevice.log.info(
+        `Setting ${cover.tahomaDevice.label} target to ${CYAN}${isValidNumber(position, 0, 10000) ? position / 100 : 'unknown'} %${nf} position and status to stopped. Movement duration: ${CYAN}${cover.movementDuration}${nf}`,
       );
-      await device.setWindowCoveringTargetAsCurrentAndStopped();
+      if (isValidNumber(position, 0, 10000)) await this.setCoverStoppedAt(cover, position);
     }
   }
 
@@ -267,15 +293,14 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
         this.log.debug(`***Tahoma update for ${device.label}: ${debugStringify(changedStates)}`);
       });
 
-      const cover = new MatterbridgeEndpoint([windowCovering, bridgedNode, powerSource], { id: device.label }, this.config.debug);
-      cover.createDefaultIdentifyClusterServer(1, Identify.IdentifyType.Actuator);
-      cover.createDefaultWindowCoveringClusterServer();
-      cover.createDefaultBridgedDeviceBasicInformationClusterServer(device.label, device.serialNumber, 0xfff1, 'Somfy Tahoma', device.definition.uiClass);
-      if (device.states.find((s) => s.name === 'core:BatteryDiscreteLevelState')) cover.createDefaultPowerSourceRechargeableBatteryClusterServer();
-      else cover.createDefaultPowerSourceWiredClusterServer();
+      const cover = new Closure(device.label, device.serialNumber, {
+        tagList: [getSemtag(ClosureTag.Covering), getSemtag(getCoveringTag(device))],
+      });
+      cover.createDefaultBasicInformationClusterServer(device.label, device.serialNumber, 0xfff1, 'Somfy Tahoma', 0x8000, device.definition.uiClass);
+      const liftPanel = cover.addPanel('Lift', [getSemtag(ClosurePanelTag.Lift)], 'lift');
       cover.addRequiredClusterServers();
       await this.registerDevice(cover);
-      this.covers.set(device.label, { tahomaDevice: device, bridgedDevice: cover, movementStatus: Stopped, movementDuration: duration });
+      this.covers.set(device.label, { tahomaDevice: device, bridgedDevice: cover, liftPanel, movementStatus: ClosureControl.MainState.Stopped, movementDuration: duration });
 
       cover.addCommandHandler('Identify.identify', async ({ request: { identifyTime } }) => {
         const cover = this.covers.get(device.label);
@@ -284,57 +309,51 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
         await this.sendCommand('identify', device, true);
       });
 
-      cover.addCommandHandler('WindowCovering.upOrOpen', () => {
+      cover.addCommandHandler('ClosureControl.moveTo', ({ request: { position } }) => {
         const cover = this.covers.get(device.label);
         if (!cover) return;
+        const targetPosition =
+          position === ClosureControl.TargetPosition.MoveToFullyOpen
+            ? WC_PERCENT100THS_MIN_OPEN
+            : position === ClosureControl.TargetPosition.MoveToFullyClosed
+              ? WC_PERCENT100THS_MAX_CLOSED
+              : undefined;
+        if (targetPosition === undefined) {
+          cover.bridgedDevice.log.warn(`Command moveTo called with unsupported position:${position}`);
+          return;
+        }
         if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
         // oxlint-disable-next-line typescript/no-misused-promises
         cover.commandTimeout = setTimeout(async () => {
           cover.commandTimeout = undefined;
-          cover.bridgedDevice.log.info(`Command ${ign}upOrOpen${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
-          await this.moveToPosition(cover, WC_PERCENT100THS_MIN_OPEN);
+          cover.bridgedDevice.log.info(`Command ${ign}moveTo${rs}${nf} ${CYAN}${targetPosition}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
+          await this.moveToPosition(cover, targetPosition);
         }, 500);
       });
 
-      cover.addCommandHandler('WindowCovering.downOrClose', () => {
+      cover.addCommandHandler('ClosureControl.stop', async () => {
         const cover = this.covers.get(device.label);
         if (!cover) return;
-        if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
-        // oxlint-disable-next-line typescript/no-misused-promises
-        cover.commandTimeout = setTimeout(async () => {
-          cover.commandTimeout = undefined;
-          cover.bridgedDevice.log.info(`Command ${ign}downOrClose${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
-          await this.moveToPosition(cover, WC_PERCENT100THS_MAX_CLOSED);
-        }, 500);
-      });
-
-      cover.addCommandHandler('WindowCovering.goToLiftPercentage', ({ request: { liftPercent100thsValue } }) => {
-        const cover = this.covers.get(device.label);
-        if (!cover) return;
-        if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
-        // oxlint-disable-next-line typescript/no-misused-promises
-        cover.commandTimeout = setTimeout(async () => {
-          cover.commandTimeout = undefined;
-          cover.bridgedDevice.log.info(`Command ${ign}goToLiftPercentage${rs}${nf} ${CYAN}${liftPercent100thsValue}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
-          await this.moveToPosition(cover, liftPercent100thsValue);
-        }, 500);
-      });
-
-      cover.addCommandHandler('WindowCovering.stopMotion', async ({ attributes }) => {
-        attributes.targetPositionLiftPercent100ths = attributes.currentPositionLiftPercent100ths;
-        attributes.operationalStatus = {
-          global: WindowCovering.MovementStatus.Stopped,
-          lift: WindowCovering.MovementStatus.Stopped,
-          tilt: WindowCovering.MovementStatus.Stopped,
-        };
-        const cover = this.covers.get(device.label);
-        if (!cover) return;
-        cover.bridgedDevice.log.info(`Command ${ign}stopMotion${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}. Status ${cover.movementStatus}`);
+        cover.bridgedDevice.log.info(`Command ${ign}stop${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}. Status ${cover.movementStatus}`);
         clearInterval(cover.moveInterval);
-        if (cover.movementStatus !== WindowCovering.MovementStatus.Stopped) {
+        cover.moveInterval = undefined;
+        if (cover.movementStatus !== ClosureControl.MainState.Stopped) {
           await this.sendCommand('stop', cover.tahomaDevice, true);
         }
-        cover.movementStatus = Stopped;
+        const position = cover.liftPanel.getAttribute(ClosureDimension, 'currentState', cover.bridgedDevice.log)?.position;
+        if (isValidNumber(position, 0, 10000)) await this.setCoverStoppedAt(cover, position);
+      });
+
+      liftPanel.addCommandHandler('ClosureDimension.setTarget', ({ request: { position } }) => {
+        const cover = this.covers.get(device.label);
+        if (!cover || position === undefined || position === null) return;
+        if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
+        // oxlint-disable-next-line typescript/no-misused-promises
+        cover.commandTimeout = setTimeout(async () => {
+          cover.commandTimeout = undefined;
+          cover.bridgedDevice.log.info(`Command ${ign}setTarget${rs}${nf} ${CYAN}${position}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
+          await this.moveToPosition(cover, position);
+        }, 500);
       });
     }
   }
@@ -342,27 +361,25 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
   // With Matter 0=open 10000=close
   async moveToPosition(cover: Cover, targetPosition: number): Promise<void> {
     const log = cover.bridgedDevice.log;
-    const position = cover.bridgedDevice.getAttribute(WindowCovering, 'currentPositionLiftPercent100ths', log);
+    const position = cover.liftPanel.getAttribute(ClosureDimension, 'currentState', log)?.position;
     if (!isValidNumber(position, 0, 10000)) return;
     let currentPosition = position;
     log.info(`Moving from ${currentPosition} to ${targetPosition}...`);
 
     // Stop movement if already moving
-    if (cover.movementStatus !== Stopped) {
+    if (cover.movementStatus !== ClosureControl.MainState.Stopped) {
       log.info('Stopping current movement.');
       clearInterval(cover.moveInterval);
       cover.moveInterval = undefined;
-      await cover.bridgedDevice.setWindowCoveringTargetAsCurrentAndStopped();
+      await this.setCoverStoppedAt(cover, currentPosition);
       await this.sendCommand('stop', cover.tahomaDevice, true);
-      cover.movementStatus = Stopped;
       return;
     }
     // Return if already at target position
     if (targetPosition === currentPosition) {
       clearInterval(cover.moveInterval);
       cover.moveInterval = undefined;
-      await cover.bridgedDevice.setWindowCoveringTargetAsCurrentAndStopped();
-      cover.movementStatus = Stopped;
+      await this.setCoverStoppedAt(cover, currentPosition);
       log.info(`Moving from ${currentPosition} to ${targetPosition}. No movement needed.`);
       return;
     }
@@ -370,9 +387,10 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
     const movement = targetPosition - currentPosition;
     const movementSeconds = Math.abs((movement * cover.movementDuration) / 10000);
     log.debug(`Moving from ${currentPosition} to ${targetPosition} in ${movementSeconds} seconds. Movement requested ${movement}`);
-    await cover.bridgedDevice.setAttribute(WindowCovering, 'targetPositionLiftPercent100ths', targetPosition, log);
-    await cover.bridgedDevice.setWindowCoveringStatus(targetPosition > currentPosition ? WindowCovering.MovementStatus.Closing : WindowCovering.MovementStatus.Opening);
-    cover.movementStatus = targetPosition > currentPosition ? Closing : Opening;
+    const targetState = cover.liftPanel.getAttribute(ClosureDimension, 'targetState', log);
+    await cover.liftPanel.setAttribute(ClosureDimension, 'targetState', { position: targetPosition, latch: targetState?.latch, speed: targetState?.speed }, log);
+    await cover.bridgedDevice.setAttribute(ClosureControl, 'mainState', ClosureControl.MainState.Moving, log);
+    cover.movementStatus = ClosureControl.MainState.Moving;
     await this.sendCommand(targetPosition > currentPosition ? 'close' : 'open', cover.tahomaDevice, true);
 
     // oxlint-disable-next-line typescript/no-misused-promises
@@ -382,20 +400,51 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
       currentPosition = Math.round(currentPosition + movement / movementSeconds);
       if (Math.abs(targetPosition - currentPosition) <= 100 || (movement > 0 && currentPosition >= targetPosition) || (movement < 0 && currentPosition <= targetPosition)) {
         clearInterval(cover.moveInterval);
-        await cover.bridgedDevice.setWindowCoveringCurrentTargetStatus(targetPosition, targetPosition, WindowCovering.MovementStatus.Stopped);
-        cover.movementStatus = Stopped;
+        await this.setCoverStoppedAt(cover, targetPosition);
         if (targetPosition !== WC_PERCENT100THS_MIN_OPEN && targetPosition !== WC_PERCENT100THS_MAX_CLOSED) await this.sendCommand('stop', cover.tahomaDevice, true);
         log.debug(`Moving stopped at ${targetPosition}`);
       } else {
         log.debug(`Moving from ${currentPosition} to ${targetPosition} difference ${Math.abs(targetPosition - currentPosition)}`);
-        await cover.bridgedDevice.setAttribute(
-          WindowCovering,
-          'currentPositionLiftPercent100ths',
-          Math.max(WC_PERCENT100THS_MIN_OPEN, Math.min(currentPosition, WC_PERCENT100THS_MAX_CLOSED)),
+        const currentState = cover.liftPanel.getAttribute(ClosureDimension, 'currentState', log);
+        await cover.liftPanel.setAttribute(
+          ClosureDimension,
+          'currentState',
+          { position: Math.max(WC_PERCENT100THS_MIN_OPEN, Math.min(currentPosition, WC_PERCENT100THS_MAX_CLOSED)), latch: currentState?.latch, speed: currentState?.speed },
           log,
         );
       }
     }, 1000);
+  }
+
+  /**
+   * Stops a cover at the given Lift position: syncs the Lift panel's ClosureDimension currentState/targetState and
+   * rolls the reached position back up into the parent Closure's ClosureControl overallCurrentState and mainState.
+   *
+   * @param {Cover} cover - The cover to update.
+   * @param {number} position - The reached position, 0 (fully open) to 10000 (fully closed).
+   * @returns {Promise<void>}
+   */
+  async setCoverStoppedAt(cover: Cover, position: number): Promise<void> {
+    const log = cover.bridgedDevice.log;
+    const currentState = cover.liftPanel.getAttribute(ClosureDimension, 'currentState', log);
+    await cover.liftPanel.setAttribute(ClosureDimension, 'currentState', { position, latch: currentState?.latch, speed: currentState?.speed }, log);
+    const targetState = cover.liftPanel.getAttribute(ClosureDimension, 'targetState', log);
+    await cover.liftPanel.setAttribute(ClosureDimension, 'targetState', { position, latch: targetState?.latch, speed: targetState?.speed }, log);
+
+    const overallCurrentState = cover.bridgedDevice.getAttribute(ClosureControl, 'overallCurrentState', log);
+    await cover.bridgedDevice.setAttribute(
+      ClosureControl.id,
+      'overallCurrentState',
+      {
+        position: closureOverallPositionFromPercent(position),
+        latch: overallCurrentState?.latch,
+        speed: overallCurrentState?.speed,
+        secureState: overallCurrentState?.secureState ?? null,
+      },
+      log,
+    );
+    await cover.bridgedDevice.setAttribute(ClosureControl, 'mainState', ClosureControl.MainState.Stopped, log);
+    cover.movementStatus = ClosureControl.MainState.Stopped;
   }
 
   async sendCommand(command: string, device: Device, highPriority = false): Promise<void> {

--- a/src/module.ts
+++ b/src/module.ts
@@ -299,7 +299,13 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
         tagList: device.definition.uiClass === 'Window' ? [getSemtag(ClosureTag.Window)] : [getSemtag(ClosureTag.Covering), getSemtag(getCoveringTag(device))],
       });
       cover.createDefaultBasicInformationClusterServer(device.label, device.serialNumber, 0xfff1, 'Somfy Tahoma', 0x8000, device.definition.uiClass);
-      const liftPanel = cover.addPanel('Lift', [getSemtag(ClosurePanelTag.Lift)], 'lift');
+      // Window openers (e.g. Velux roof windows) open by rotating on a hinge, not by translating up/down like a
+      // shutter or blind, so their panel must advertise the Rotation feature (ClosureDimension.Feature.Rotation) via
+      // a 'tilt' panel tagged ClosurePanelTag.Tilt instead of a 'lift'/ClosurePanelTag.Lift (Translation) panel.
+      const liftPanel =
+        device.definition.uiClass === 'Window'
+          ? cover.addPanel('Tilt', [getSemtag(ClosurePanelTag.Tilt)], 'tilt')
+          : cover.addPanel('Lift', [getSemtag(ClosurePanelTag.Lift)], 'lift');
       cover.addRequiredClusterServers();
       await this.registerDevice(cover);
       this.covers.set(device.label, { tahomaDevice: device, bridgedDevice: cover, liftPanel, movementStatus: ClosureControl.MainState.Stopped, movementDuration: duration });

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -13,7 +13,7 @@ import { promises as fs } from 'node:fs';
 
 import type { PlatformMatterbridge } from 'matterbridge';
 import { BLUE, CYAN, ign, LogLevel, nf, rs, YELLOW } from 'matterbridge/logger';
-import { WindowCovering } from 'matterbridge/matter/clusters';
+import { ClosureControl, ClosureDimension } from 'matterbridge/matter/clusters';
 import { wait } from 'matterbridge/utils';
 import { flushAsync, log, loggerLogSpy, setDebug, setupTest } from 'matterbridge/vitest-utils';
 import {
@@ -265,7 +265,7 @@ describe('SomfyTahomaPlatform', () => {
     await flushAsync();
   });
 
-  it('should add a rechargeable battery cover and handle device state updates', async () => {
+  it('should add a cover for a battery powered device and handle device state updates', async () => {
     setMockDevice({ label: 'Device1', uniqueName: 'Blind' });
     mockDevices[0].states = [{ name: 'core:BatteryDiscreteLevelState', type: 3, value: 'normal' } satisfies State];
     clientGetDevicesSpy.mockResolvedValueOnce(mockDevices);
@@ -310,69 +310,129 @@ describe('SomfyTahomaPlatform', () => {
     await somfyPlatform.sendCommand('close', mockDevices[0]);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.ERROR, expect.stringContaining(`Error sending command`));
 
-    const device = somfyPlatform.covers.get('Device1')?.bridgedDevice;
-    expect(device).toBeDefined();
-    if (!device) return;
-    await device.setWindowCoveringCurrentTargetStatus(WC_PERCENT100THS_MIN_OPEN, WC_PERCENT100THS_MIN_OPEN, WindowCovering.MovementStatus.Stopped);
+    const cover = somfyPlatform.covers.get('Device1');
+    expect(cover).toBeDefined();
+    if (!cover) return;
+    const device = cover.bridgedDevice;
+    const liftPanel = cover.liftPanel;
+    await somfyPlatform.setCoverStoppedAt(cover, WC_PERCENT100THS_MIN_OPEN);
 
     vi.clearAllMocks();
     await device.executeCommandHandler('Identify.identify', { identifyTime: 1 }, 'identify', (device.state as any).identify, device);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}identify${rs}${nf} called identifyTime:1`);
 
     vi.clearAllMocks();
-    await device.executeCommandHandler('WindowCovering.downOrClose', {}, 'windowCovering', (device.state as any).windowCovering, device);
+    await device.executeCommandHandler(
+      'ClosureControl.moveTo',
+      { position: ClosureControl.TargetPosition.MoveToPedestrianPosition },
+      'closureControl',
+      (device.state as any).closureControl,
+      device,
+    );
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.WARN, `Command moveTo called with unsupported position:${ClosureControl.TargetPosition.MoveToPedestrianPosition}`);
+
+    vi.clearAllMocks();
+    await device.executeCommandHandler(
+      'ClosureControl.moveTo',
+      { position: ClosureControl.TargetPosition.MoveToFullyClosed },
+      'closureControl',
+      (device.state as any).closureControl,
+      device,
+    );
     await wait(3000);
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}downOrClose${rs}${nf} called for ${CYAN}${mockDevices[0].label}`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}moveTo${rs}${nf} ${CYAN}${WC_PERCENT100THS_MAX_CLOSED}${nf} called for ${CYAN}${mockDevices[0].label}`);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Moving from ${WC_PERCENT100THS_MIN_OPEN} to ${WC_PERCENT100THS_MAX_CLOSED}...`);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, `Moving stopped at ${WC_PERCENT100THS_MAX_CLOSED}`);
-    expect(device.getAttribute(WindowCovering.id, 'currentPositionLiftPercent100ths')).toBe(WC_PERCENT100THS_MAX_CLOSED);
+    expect(liftPanel.getAttribute(ClosureDimension.id, 'currentState')?.position).toBe(WC_PERCENT100THS_MAX_CLOSED);
 
     vi.clearAllMocks();
-    await device.executeCommandHandler('WindowCovering.upOrOpen', {}, 'windowCovering', (device.state as any).windowCovering, device);
+    await device.executeCommandHandler(
+      'ClosureControl.moveTo',
+      { position: ClosureControl.TargetPosition.MoveToFullyOpen },
+      'closureControl',
+      (device.state as any).closureControl,
+      device,
+    );
     await wait(3000);
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}upOrOpen${rs}${nf} called for ${CYAN}${mockDevices[0].label}`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}moveTo${rs}${nf} ${CYAN}${WC_PERCENT100THS_MIN_OPEN}${nf} called for ${CYAN}${mockDevices[0].label}`);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Moving from ${WC_PERCENT100THS_MAX_CLOSED} to ${WC_PERCENT100THS_MIN_OPEN}...`);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, `Moving stopped at ${WC_PERCENT100THS_MIN_OPEN}`);
-    expect(device.getAttribute(WindowCovering.id, 'currentPositionLiftPercent100ths')).toBe(WC_PERCENT100THS_MIN_OPEN);
+    expect(liftPanel.getAttribute(ClosureDimension.id, 'currentState')?.position).toBe(WC_PERCENT100THS_MIN_OPEN);
 
     vi.clearAllMocks();
-    await device.executeCommandHandler('WindowCovering.upOrOpen', {}, 'windowCovering', (device.state as any).windowCovering, device);
+    await device.executeCommandHandler(
+      'ClosureControl.moveTo',
+      { position: ClosureControl.TargetPosition.MoveToFullyOpen },
+      'closureControl',
+      (device.state as any).closureControl,
+      device,
+    );
     await wait(3000);
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}upOrOpen${rs}${nf} called for ${CYAN}${mockDevices[0].label}`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}moveTo${rs}${nf} ${CYAN}${WC_PERCENT100THS_MIN_OPEN}${nf} called for ${CYAN}${mockDevices[0].label}`);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Moving from ${WC_PERCENT100THS_MIN_OPEN} to ${WC_PERCENT100THS_MIN_OPEN}...`);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Moving from ${WC_PERCENT100THS_MIN_OPEN} to ${WC_PERCENT100THS_MIN_OPEN}. No movement needed.`);
-    expect(device.getAttribute(WindowCovering.id, 'currentPositionLiftPercent100ths')).toBe(WC_PERCENT100THS_MIN_OPEN);
+    expect(liftPanel.getAttribute(ClosureDimension.id, 'currentState')?.position).toBe(WC_PERCENT100THS_MIN_OPEN);
 
     vi.clearAllMocks();
-    await device.executeCommandHandler('WindowCovering.goToLiftPercentage', { liftPercent100thsValue: 5000 }, 'windowCovering', (device.state as any).windowCovering, device);
+    await liftPanel.executeCommandHandler('ClosureDimension.setTarget', { position: 5000 }, 'closureDimension', (liftPanel.state as any).closureDimension, liftPanel);
     await wait(3000);
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}goToLiftPercentage${rs}${nf} ${CYAN}5000${nf} called for ${CYAN}${mockDevices[0].label}`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}setTarget${rs}${nf} ${CYAN}5000${nf} called for ${CYAN}${mockDevices[0].label}`);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Moving from ${WC_PERCENT100THS_MIN_OPEN} to 5000...`);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, `Moving stopped at 5000`);
-    expect(device.getAttribute(WindowCovering.id, 'currentPositionLiftPercent100ths')).toBe(5000);
+    expect(liftPanel.getAttribute(ClosureDimension.id, 'currentState')?.position).toBe(5000);
 
     vi.clearAllMocks();
-    await device.executeCommandHandler('WindowCovering.goToLiftPercentage', { liftPercent100thsValue: 10000 }, 'windowCovering', (device.state as any).windowCovering, device);
+    await liftPanel.executeCommandHandler('ClosureDimension.setTarget', { position: 10000 }, 'closureDimension', (liftPanel.state as any).closureDimension, liftPanel);
     await wait(3000);
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}goToLiftPercentage${rs}${nf} ${CYAN}10000${nf} called for ${CYAN}${mockDevices[0].label}`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}setTarget${rs}${nf} ${CYAN}10000${nf} called for ${CYAN}${mockDevices[0].label}`);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Moving from 5000 to ${WC_PERCENT100THS_MAX_CLOSED}...`);
 
     vi.clearAllMocks();
-    await device.executeCommandHandler('WindowCovering.downOrClose', {}, 'windowCovering', (device.state as any).windowCovering, device);
+    await device.executeCommandHandler(
+      'ClosureControl.moveTo',
+      { position: ClosureControl.TargetPosition.MoveToFullyClosed },
+      'closureControl',
+      (device.state as any).closureControl,
+      device,
+    );
     await wait(1000);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Moving from ${WC_PERCENT100THS_MAX_CLOSED} to ${WC_PERCENT100THS_MAX_CLOSED}...`);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Moving from ${WC_PERCENT100THS_MAX_CLOSED} to ${WC_PERCENT100THS_MAX_CLOSED}. No movement needed.`);
 
     vi.clearAllMocks();
-    await device.executeCommandHandler('WindowCovering.downOrClose', {}, 'windowCovering', (device.state as any).windowCovering, device);
+    await device.executeCommandHandler(
+      'ClosureControl.moveTo',
+      { position: ClosureControl.TargetPosition.MoveToFullyClosed },
+      'closureControl',
+      (device.state as any).closureControl,
+      device,
+    );
     await wait(1000);
-    expect(device.getAttribute(WindowCovering.id, 'currentPositionLiftPercent100ths')).toBe(WC_PERCENT100THS_MAX_CLOSED);
+    expect(liftPanel.getAttribute(ClosureDimension.id, 'currentState')?.position).toBe(WC_PERCENT100THS_MAX_CLOSED);
 
-    await device.executeCommandHandler('WindowCovering.upOrOpen', {}, 'windowCovering', (device.state as any).windowCovering, device);
-    await device.executeCommandHandler('WindowCovering.stopMotion', {}, 'windowCovering', {} as any, device);
-    await device.executeCommandHandler('WindowCovering.downOrClose', {}, 'windowCovering', (device.state as any).windowCovering, device);
-    await device.executeCommandHandler('WindowCovering.upOrOpen', {}, 'windowCovering', (device.state as any).windowCovering, device);
-    await device.executeCommandHandler('WindowCovering.stopMotion', {}, 'windowCovering', {} as any, device);
+    await device.executeCommandHandler(
+      'ClosureControl.moveTo',
+      { position: ClosureControl.TargetPosition.MoveToFullyOpen },
+      'closureControl',
+      (device.state as any).closureControl,
+      device,
+    );
+    await device.executeCommandHandler('ClosureControl.stop', {}, 'closureControl', (device.state as any).closureControl, device);
+    await device.executeCommandHandler(
+      'ClosureControl.moveTo',
+      { position: ClosureControl.TargetPosition.MoveToFullyClosed },
+      'closureControl',
+      (device.state as any).closureControl,
+      device,
+    );
+    await device.executeCommandHandler(
+      'ClosureControl.moveTo',
+      { position: ClosureControl.TargetPosition.MoveToFullyOpen },
+      'closureControl',
+      (device.state as any).closureControl,
+      device,
+    );
+    await device.executeCommandHandler('ClosureControl.stop', {}, 'closureControl', (device.state as any).closureControl, device);
 
     somfyPlatform.tahomaDevices = [];
     somfyPlatform.covers.clear();
@@ -429,8 +489,8 @@ describe('SomfyTahomaPlatform', () => {
     expect(cover).toBeDefined();
     if (!cover) return;
 
-    await cover.bridgedDevice.setWindowCoveringCurrentTargetStatus(5000, 5000, WindowCovering.MovementStatus.Stopped);
-    cover.movementStatus = WindowCovering.MovementStatus.Opening;
+    await somfyPlatform.setCoverStoppedAt(cover, 5000);
+    cover.movementStatus = ClosureControl.MainState.Moving;
     cover.moveInterval = setInterval(() => {
       // noop
     }, 1000);
@@ -439,26 +499,26 @@ describe('SomfyTahomaPlatform', () => {
 
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'Stopping current movement.');
     expect(clientExecuteSpy).toHaveBeenCalledWith('apply/highPriority', expect.anything());
-    expect(cover.movementStatus).toBe(WindowCovering.MovementStatus.Stopped);
+    expect(cover.movementStatus).toBe(ClosureControl.MainState.Stopped);
     expect(cover.moveInterval).toBeUndefined();
   });
 
-  it('should send stop on stopMotion when movementStatus is not stopped', async () => {
+  it('should send stop on stop when movementStatus is not stopped', async () => {
     const cover = somfyPlatform.covers.get('Device1');
     expect(cover).toBeDefined();
     if (!cover) return;
     const device = cover.bridgedDevice;
 
-    await cover.bridgedDevice.setWindowCoveringCurrentTargetStatus(5000, 5000, WindowCovering.MovementStatus.Stopped);
-    cover.movementStatus = WindowCovering.MovementStatus.Opening;
+    await somfyPlatform.setCoverStoppedAt(cover, 5000);
+    cover.movementStatus = ClosureControl.MainState.Moving;
     cover.moveInterval = setInterval(() => {
       // noop
     }, 1000);
 
-    await device.executeCommandHandler('WindowCovering.stopMotion', {}, 'windowCovering', {} as any, device);
+    await device.executeCommandHandler('ClosureControl.stop', {}, 'closureControl', (device.state as any).closureControl, device);
 
     expect(clientExecuteSpy).toHaveBeenCalledWith('apply/highPriority', expect.anything());
-    expect(cover.movementStatus).toBe(WindowCovering.MovementStatus.Stopped);
+    expect(cover.movementStatus).toBe(ClosureControl.MainState.Stopped);
   });
 
   it('should call onConfigure', async () => {

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -13,6 +13,7 @@ import { promises as fs } from 'node:fs';
 
 import type { PlatformMatterbridge } from 'matterbridge';
 import { BLUE, CYAN, ign, LogLevel, nf, rs, YELLOW } from 'matterbridge/logger';
+import { ClosureTag } from 'matterbridge/matter';
 import { ClosureControl, ClosureDimension } from 'matterbridge/matter/clusters';
 import { wait } from 'matterbridge/utils';
 import { flushAsync, log, loggerLogSpy, setDebug, setupTest } from 'matterbridge/vitest-utils';
@@ -258,6 +259,19 @@ describe('SomfyTahomaPlatform', () => {
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, `Adding device: ${BLUE}${mockDevices[0].label}${rs}`);
     expect(somfyPlatform.getDevices()).toHaveLength(1);
     expect(somfyPlatform.covers.size).toBe(1);
+    somfyPlatform.tahomaDevices = [];
+    somfyPlatform.covers.clear();
+    await somfyPlatform.unregisterAllDevices();
+    expect(aggregator.parts.size).toBe(0);
+    await flushAsync();
+  });
+
+  it('should tag a Window uiClass device with ClosureTag.Window and no covering subtype', async () => {
+    setMockDevice({ label: 'Device1', uniqueName: 'WindowOpenerVeluxIOComponent', uiClass: 'Window', commands: ['open', 'close', 'stop'] });
+    clientGetDevicesSpy.mockResolvedValueOnce(mockDevices);
+    await somfyPlatform.discoverDevices();
+    const cover = somfyPlatform.covers.get('Device1');
+    expect(cover?.bridgedDevice.tagList).toEqual([{ mfgCode: null, namespaceId: ClosureTag.Window.namespaceId, tag: ClosureTag.Window.tag }]);
     somfyPlatform.tahomaDevices = [];
     somfyPlatform.covers.clear();
     await somfyPlatform.unregisterAllDevices();

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -13,7 +13,7 @@ import { promises as fs } from 'node:fs';
 
 import type { PlatformMatterbridge } from 'matterbridge';
 import { BLUE, CYAN, ign, LogLevel, nf, rs, YELLOW } from 'matterbridge/logger';
-import { ClosureTag } from 'matterbridge/matter';
+import { ClosurePanelTag, ClosureTag } from 'matterbridge/matter';
 import { ClosureControl, ClosureDimension } from 'matterbridge/matter/clusters';
 import { wait } from 'matterbridge/utils';
 import { flushAsync, log, loggerLogSpy, setDebug, setupTest } from 'matterbridge/vitest-utils';
@@ -266,12 +266,16 @@ describe('SomfyTahomaPlatform', () => {
     await flushAsync();
   });
 
-  it('should tag a Window uiClass device with ClosureTag.Window and no covering subtype', async () => {
+  it('should tag a Window uiClass device with ClosureTag.Window and a rotating Tilt panel', async () => {
     setMockDevice({ label: 'Device1', uniqueName: 'WindowOpenerVeluxIOComponent', uiClass: 'Window', commands: ['open', 'close', 'stop'] });
     clientGetDevicesSpy.mockResolvedValueOnce(mockDevices);
     await somfyPlatform.discoverDevices();
     const cover = somfyPlatform.covers.get('Device1');
     expect(cover?.bridgedDevice.tagList).toEqual([{ mfgCode: null, namespaceId: ClosureTag.Window.namespaceId, tag: ClosureTag.Window.tag }]);
+    expect(cover?.liftPanel.tagList).toEqual([{ mfgCode: null, namespaceId: ClosurePanelTag.Tilt.namespaceId, tag: ClosurePanelTag.Tilt.tag }]);
+    // A rotating window opener supports the Rotation feature (rotationAxis attribute), not Translation (translationDirection attribute)
+    expect(cover?.liftPanel.hasAttributeServer(ClosureDimension, 'rotationAxis')).toBe(true);
+    expect(cover?.liftPanel.hasAttributeServer(ClosureDimension, 'translationDirection')).toBe(false);
     somfyPlatform.tahomaDevices = [];
     somfyPlatform.covers.clear();
     await somfyPlatform.unregisterAllDevices();


### PR DESCRIPTION
## Summary

Experimental switch of Tahoma cover endpoints from `windowCovering` to the new Matter 1.5 `Closure` device type (`ClosureControl` + a `ClosureDimension` panel), to try it out against real Somfy Tahoma covers.

- Replace the windowCovering-based cover endpoint with `Closure` + a single Lift `ClosureDimension` panel.
  - Map each discovered device's `uiClass` to the closest `ClosureCoveringTag` (Shutter/Venetian/Awning/Blind) for endpoint disambiguation.
  - Reuse the existing percent-based (0-10000) movement simulation, now driving the Lift panel's `ClosureDimension` state and rolling it back up into the parent `Closure`'s `ClosureControl` state.
  - `ClosureControl.moveTo`/`stop` handle discrete open/close/stop; `ClosureDimension.setTarget` on the Lift panel handles arbitrary percent positions.
  - Drop the PowerSource/battery cluster: the single-class `Closure` device type is fixed to `[closure]`, so battery reporting would require changing matterbridge core itself — out of scope here.
- Tag roof/skylight window openers (e.g. Velux, `uiClass` "Window") with `ClosureTag.Window` instead of a `ClosureCoveringTag` material subtype, since they're a Closure in their own right (Application Cluster Spec § 22), not a covering (§ 24 only qualifies actual coverings like blinds/shutters/awnings).
- For those same Window devices, advertise a Tilt panel (`ClosurePanelTag.Tilt`, Rotation feature) instead of a Lift panel (Translation feature), since roof windows open by rotating on a hinge, not by translating like a shutter/blind.
- Update `vitest/module.test.ts` to match the new command handlers/attributes.

## Why draft

This is a try-out branch (`test/closure-device-type`) validating the new device type against real hardware before deciding whether to bring it into `dev` properly — opening as draft for visibility/discussion, not necessarily ready to merge as-is.

## Testing

- `vitest/module.test.ts` updated and passing (25 tests, 100% line/function coverage per the last local run).
- Manually exercised against real Somfy Tahoma covers.