### PR TITLE
feat(closure): add useClosure option to expose covers as Matter 1.5 Closure devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ If you like this project and find it useful, please consider giving it a star on
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="120"></a>
 
+## [1.7.0] - 2026-08-22
+
+### Breaking changes
+
+- [matterbridge]: Require matterbridge v.3.10.7 (dev branch build with Closure device support).
+
+### Added
+
+- [config]: Add the `useClosure` config option (default `false`) to expose covers using the Matter 1.5 Closure device type instead of WindowCovering, to ease integration testing with controllers that support the newer cluster. Requires a matterbridge dev branch build with Closure support.
+
+<a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
+
 ## [1.6.0] - 2026-07-17
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ If you like this project and find it useful, please consider giving it a star on
 ### Added
 
 - [config]: Add the `useClosure` config option (default `false`) to expose covers using the Matter 1.5 Closure device type instead of WindowCovering, to ease integration testing with controllers that support the newer cluster. Requires a matterbridge dev branch build with Closure support.
+- [config]: Add the `closureCalibration`, `closureVentilation` and `closurePedestrian` per-device config options to opt in to the Closure Calibration, Ventilation and Pedestrian optional features on a device basis. Only applies when `useClosure` is enabled.
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Set for each device the full movement time (the plugin will use that time to syn
 
 If `useClosure` is enabled, covers are exposed using the Matter 1.5 Closure device type instead of WindowCovering. This eases integration testing with controllers that support the newer cluster, and requires a matterbridge build with Closure support (development only).
 
+When `useClosure` is enabled, you can opt in per device to the Closure `Calibration`, `Ventilation` and `Pedestrian` optional features with `closureCalibration`, `closureVentilation` and `closurePedestrian`.
+
 These are the config values:
 
 ```json
@@ -73,7 +75,16 @@ These are the config values:
     "<DEVICENAME1>": 30,
     "<DEVICENAME2>": 30
   },
-  "useClosure": false
+  "useClosure": false,
+  "closureCalibration": {
+    "<DEVICENAME1>": true
+  },
+  "closureVentilation": {
+    "<DEVICENAME1>": true
+  },
+  "closurePedestrian": {
+    "<DEVICENAME1>": true
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If any device creates issues put it in the blackList.
 
 Set for each device the full movement time (the plugin will use that time to syncronize the movement).
 
+If `useClosure` is enabled, covers are exposed using the Matter 1.5 Closure device type instead of WindowCovering. This eases integration testing with controllers that support the newer cluster, and requires a matterbridge build with Closure support (development only).
+
 These are the config values:
 
 ```json
@@ -70,7 +72,8 @@ These are the config values:
   "duration": {
     "<DEVICENAME1>": 30,
     "<DEVICENAME2>": 30
-  }
+  },
+  "useClosure": false
 }
 ```
 

--- a/matterbridge-somfy-tahoma.config.json
+++ b/matterbridge-somfy-tahoma.config.json
@@ -9,6 +9,9 @@
   "whiteList": [],
   "movementDuration": {},
   "useClosure": false,
+  "closureCalibration": {},
+  "closureVentilation": {},
+  "closurePedestrian": {},
   "debug": false,
   "unregisterOnShutdown": false
 }

--- a/matterbridge-somfy-tahoma.config.json
+++ b/matterbridge-somfy-tahoma.config.json
@@ -8,6 +8,7 @@
   "blackList": [],
   "whiteList": [],
   "movementDuration": {},
+  "useClosure": false,
   "debug": false,
   "unregisterOnShutdown": false
 }

--- a/matterbridge-somfy-tahoma.schema.json
+++ b/matterbridge-somfy-tahoma.schema.json
@@ -88,6 +88,36 @@
       "type": "boolean",
       "default": false
     },
+    "closureCalibration": {
+      "title": "Closure Calibration",
+      "description": "Opt in per device to the Closure Calibration optional feature. Enter in the first field the name of the device and in the second field true or false. Only applies when useClosure is enabled (development only)",
+      "type": "object",
+      "uniqueItems": true,
+      "selectFrom": "name",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "closureVentilation": {
+      "title": "Closure Ventilation",
+      "description": "Opt in per device to the Closure Ventilation optional feature. Enter in the first field the name of the device and in the second field true or false. Only applies when useClosure is enabled (development only)",
+      "type": "object",
+      "uniqueItems": true,
+      "selectFrom": "name",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "closurePedestrian": {
+      "title": "Closure Pedestrian",
+      "description": "Opt in per device to the Closure Pedestrian optional feature. Enter in the first field the name of the device and in the second field true or false. Only applies when useClosure is enabled (development only)",
+      "type": "object",
+      "uniqueItems": true,
+      "selectFrom": "name",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
     "debug": {
       "title": "Enable Debug",
 

--- a/matterbridge-somfy-tahoma.schema.json
+++ b/matterbridge-somfy-tahoma.schema.json
@@ -82,6 +82,12 @@
         "type": "integer"
       }
     },
+    "useClosure": {
+      "title": "Use Closure",
+      "description": "Expose covers using the Matter 1.5 Closure device type instead of WindowCovering, to ease integration testing with controllers that support the newer cluster. Requires a matterbridge build with Closure support (development only)",
+      "type": "boolean",
+      "default": false
+    },
     "debug": {
       "title": "Enable Debug",
 

--- a/matterbridge-somfy-tahoma.schema.json
+++ b/matterbridge-somfy-tahoma.schema.json
@@ -92,7 +92,6 @@
       "title": "Closure Calibration",
       "description": "Opt in per device to the Closure Calibration optional feature. Enter in the first field the name of the device and in the second field true or false. Only applies when useClosure is enabled (development only)",
       "type": "object",
-      "uniqueItems": true,
       "selectFrom": "name",
       "additionalProperties": {
         "type": "boolean"
@@ -102,7 +101,6 @@
       "title": "Closure Ventilation",
       "description": "Opt in per device to the Closure Ventilation optional feature. Enter in the first field the name of the device and in the second field true or false. Only applies when useClosure is enabled (development only)",
       "type": "object",
-      "uniqueItems": true,
       "selectFrom": "name",
       "additionalProperties": {
         "type": "boolean"
@@ -112,7 +110,6 @@
       "title": "Closure Pedestrian",
       "description": "Opt in per device to the Closure Pedestrian optional feature. Enter in the first field the name of the device and in the second field true or false. Only applies when useClosure is enabled (development only)",
       "type": "object",
-      "uniqueItems": true,
       "selectFrom": "name",
       "additionalProperties": {
         "type": "boolean"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-somfy-tahoma",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Matterbridge somfy tahoma plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/src/module.ts
+++ b/src/module.ts
@@ -69,6 +69,12 @@ export type SomfyTahomaPlatformConfig = PlatformConfig & {
   movementDuration: MovementDuration;
   /** Expose covers using the Matter 1.5 Closure device type instead of WindowCovering. Requires a matterbridge build with Closure support. Default: false. */
   useClosure?: boolean;
+  /** Per-device opt-in for the Closure Calibration optional feature. Enter the device name and true/false. Only applies when useClosure is enabled. Default: false for all devices. */
+  closureCalibration?: Record<string, boolean>;
+  /** Per-device opt-in for the Closure Ventilation optional feature. Enter the device name and true/false. Only applies when useClosure is enabled. Default: false for all devices. */
+  closureVentilation?: Record<string, boolean>;
+  /** Per-device opt-in for the Closure Pedestrian optional feature. Enter the device name and true/false. Only applies when useClosure is enabled. Default: false for all devices. */
+  closurePedestrian?: Record<string, boolean>;
 };
 
 /**
@@ -410,6 +416,9 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
         const closureCover = new Closure(device.label, device.serialNumber, {
           powerSourceType: device.states.find((s) => s.name === 'core:BatteryDiscreteLevelState') ? 'Rechargeable' : 'Wired',
           tagList: isWindow ? [getSemtag(ClosureTag.Window)] : [getSemtag(ClosureTag.Covering), getSemtag(getCoveringTag(device))],
+          calibration: this.config.closureCalibration?.[device.label],
+          ventilation: this.config.closureVentilation?.[device.label],
+          pedestrian: this.config.closurePedestrian?.[device.label],
         });
         closureCover.createDefaultBasicInformationClusterServer(device.label, device.serialNumber, 0xfff1, 'Somfy Tahoma', 0x8000, device.definition.uiClass);
         // Window openers open by rotating on a hinge, not by translating up/down like a shutter or blind, so their

--- a/src/module.ts
+++ b/src/module.ts
@@ -433,7 +433,10 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
         // Window openers (e.g. Velux roof windows) are a Closure in their own right (ClosureTag.Window), not a covering,
         // so the ClosureCoveringTag material subtype only applies to actual coverings (blinds, shutters, awnings, ...).
         const isWindow = device.definition.uiClass === 'Window';
-          tagList: isWindow ? [getSemtag(ClosureTag.Window)] : [getSemtag(ClosureTag.Covering), getCoveringTag(device)],
+        const closureCover = new Closure(device.label, device.serialNumber, {
+          powerSourceType: device.states.find((s) => s.name === 'core:BatteryDiscreteLevelState') ? 'Rechargeable' : 'Wired',
+          tagList: isWindow ? [getSemtag(ClosureTag.Window)] : [getSemtag(ClosureTag.Covering), getSemtag(getCoveringTag(device))],
+          calibration: this.config.closureCalibration?.[device.label],
           ventilation: this.config.closureVentilation?.[device.label],
           pedestrian: this.config.closurePedestrian?.[device.label],
         });

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@
  * @description This file contains the class SomfyTahomaPlatform.
  * @author Luca Liguori
  * @created 2024-03-06
- * @version 1.4.2
+ * @version 1.7.0
  * @license Apache-2.0
  *
  * Copyright 2025, 2026, 2027 Luca Liguori.
@@ -24,9 +24,20 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { bridgedNode, MatterbridgeDynamicPlatform, MatterbridgeEndpoint, type PlatformConfig, type PlatformMatterbridge, powerSource, windowCovering } from 'matterbridge';
+import {
+  bridgedNode,
+  getSemtag,
+  MatterbridgeDynamicPlatform,
+  MatterbridgeEndpoint,
+  type PlatformConfig,
+  type PlatformMatterbridge,
+  powerSource,
+  windowCovering,
+} from 'matterbridge';
+import { Closure } from 'matterbridge/devices';
 import { type AnsiLogger, BLUE, CYAN, debugStringify, ign, nf, rs, stringify, YELLOW } from 'matterbridge/logger';
-import { Identify, WindowCovering } from 'matterbridge/matter/clusters';
+import { ClosureCoveringTag, ClosurePanelTag, ClosureTag } from 'matterbridge/matter';
+import { ClosureControl, ClosureDimension, Identify, WindowCovering } from 'matterbridge/matter/clusters';
 import { inspectError, isValidNumber, isValidString } from 'matterbridge/utils';
 import { Action, Client, Command, type Device, Execution, type State } from 'overkiz-client';
 
@@ -40,7 +51,10 @@ export const WC_PERCENT100THS_MAX_CLOSED = 10000;
 interface Cover {
   tahomaDevice: Device;
   bridgedDevice: MatterbridgeEndpoint;
+  /** The Closure Lift/Tilt panel child endpoint. Only set when the cover is exposed with `useClosure` enabled. */
+  liftPanel?: MatterbridgeEndpoint;
   movementDuration: number;
+  // Internal bookkeeping only: never written directly to the Closure cluster, which uses its own `mainState` attribute (see setCoverMoving/setCoverStoppedAt).
   movementStatus: WindowCovering.MovementStatus;
   moveInterval?: NodeJS.Timeout;
   commandTimeout?: NodeJS.Timeout;
@@ -53,7 +67,126 @@ export type SomfyTahomaPlatformConfig = PlatformConfig & {
   whiteList: string[];
   blackList: string[];
   movementDuration: MovementDuration;
+  /** Expose covers using the Matter 1.5 Closure device type instead of WindowCovering. Requires a matterbridge build with Closure support. Default: false. */
+  useClosure?: boolean;
 };
+
+/**
+ * Maps a discovered TaHoma device's uiClass to the closest ClosureCoveringTag semantic tag, used to disambiguate
+ * the Closure endpoint (Application Cluster Specification § 24, ClosureCoveringTag namespace).
+ *
+ * @param {Device} device - The discovered TaHoma device.
+ * @returns {typeof ClosureCoveringTag.Shutter} The semantic tag describing the covering type.
+ */
+function getCoveringTag(device: Device): typeof ClosureCoveringTag.Shutter {
+  const uiClass = device.definition.uiClass;
+  if (uiClass === 'VenetianBlind' || uiClass === 'ExteriorVenetianBlind') return ClosureCoveringTag.Venetian;
+  if (uiClass === 'Awning' || uiClass === 'Pergola') return ClosureCoveringTag.Awning;
+  if (uiClass === 'Screen' || uiClass === 'ExteriorScreen') return ClosureCoveringTag.Blind;
+  return ClosureCoveringTag.Shutter; // Shutter, RollerShutter and any other supported uiClass
+}
+
+/**
+ * Resolves the coarse ClosureControl.CurrentPosition enum matching a Lift/Tilt panel percent position.
+ *
+ * @param {number} percent - The panel position, 0 (fully open) to 10000 (fully closed).
+ * @returns {ClosureControl.CurrentPosition} The coarse overall current position.
+ */
+function closureOverallPositionFromPercent(percent: number): ClosureControl.CurrentPosition {
+  if (percent <= WC_PERCENT100THS_MIN_OPEN) return ClosureControl.CurrentPosition.FullyOpened;
+  if (percent >= WC_PERCENT100THS_MAX_CLOSED) return ClosureControl.CurrentPosition.FullyClosed;
+  return ClosureControl.CurrentPosition.PartiallyOpened;
+}
+
+/**
+ * Reads the current Lift/Tilt position from the cover's underlying cluster, whichever device type (WindowCovering
+ * or Closure, see the `useClosure` config option) is currently in use.
+ *
+ * @param {Cover} cover - The cover to read from.
+ * @returns {number | null | undefined} The current position, 0 (fully open) to 10000 (fully closed), or null/undefined if not yet known.
+ */
+function getCoverPosition(cover: Cover): number | null | undefined {
+  const log = cover.bridgedDevice.log;
+  return cover.liftPanel
+    ? cover.liftPanel.getAttribute(ClosureDimension, 'currentState', log)?.position
+    : cover.bridgedDevice.getAttribute(WindowCovering, 'currentPositionLiftPercent100ths', log);
+}
+
+/**
+ * Parks the cover at the given position and marks it stopped, on whichever cluster (WindowCovering or Closure) is
+ * currently in use. Updates `cover.movementStatus`.
+ *
+ * @param {Cover} cover - The cover to update.
+ * @param {number} position - The reached position, 0 (fully open) to 10000 (fully closed).
+ * @returns {Promise<void>}
+ */
+async function setCoverStoppedAt(cover: Cover, position: number): Promise<void> {
+  const log = cover.bridgedDevice.log;
+  if (cover.liftPanel) {
+    const currentState = cover.liftPanel.getAttribute(ClosureDimension, 'currentState', log);
+    await cover.liftPanel.setAttribute(ClosureDimension, 'currentState', { position, latch: currentState?.latch, speed: currentState?.speed }, log);
+    const targetState = cover.liftPanel.getAttribute(ClosureDimension, 'targetState', log);
+    await cover.liftPanel.setAttribute(ClosureDimension, 'targetState', { position, latch: targetState?.latch, speed: targetState?.speed }, log);
+
+    const overallCurrentState = cover.bridgedDevice.getAttribute(ClosureControl, 'overallCurrentState', log);
+    const overallTargetState = cover.bridgedDevice.getAttribute(ClosureControl, 'overallTargetState', log);
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- cover.liftPanel is only set when bridgedDevice is a Closure (see discoverDevices)
+    await (cover.bridgedDevice as Closure).setState(
+      {
+        position: closureOverallPositionFromPercent(position),
+        latch: overallCurrentState?.latch,
+        speed: overallCurrentState?.speed,
+        secureState: overallCurrentState?.secureState ?? null,
+      },
+      overallTargetState ?? { position: ClosureControl.TargetPosition.MoveToFullyClosed, latch: true },
+      ClosureControl.MainState.Stopped,
+    );
+  } else {
+    await cover.bridgedDevice.setWindowCoveringCurrentTargetStatus(position, position, WindowCovering.MovementStatus.Stopped);
+  }
+  cover.movementStatus = Stopped;
+}
+
+/**
+ * Marks the cover as moving towards a target position, on whichever cluster (WindowCovering or Closure) is
+ * currently in use. Updates `cover.movementStatus`.
+ *
+ * @param {Cover} cover - The cover to update.
+ * @param {number} targetPosition - The requested target position, 0 (fully open) to 10000 (fully closed).
+ * @param {boolean} closing - Whether the cover is moving towards fully closed (true) or fully open (false).
+ * @returns {Promise<void>}
+ */
+async function setCoverMoving(cover: Cover, targetPosition: number, closing: boolean): Promise<void> {
+  const log = cover.bridgedDevice.log;
+  if (cover.liftPanel) {
+    const targetState = cover.liftPanel.getAttribute(ClosureDimension, 'targetState', log);
+    await cover.liftPanel.setAttribute(ClosureDimension, 'targetState', { position: targetPosition, latch: targetState?.latch, speed: targetState?.speed }, log);
+    await cover.bridgedDevice.setAttribute(ClosureControl, 'mainState', ClosureControl.MainState.Moving, log);
+  } else {
+    await cover.bridgedDevice.setAttribute(WindowCovering, 'targetPositionLiftPercent100ths', targetPosition, log);
+    await cover.bridgedDevice.setWindowCoveringStatus(closing ? WindowCovering.MovementStatus.Closing : WindowCovering.MovementStatus.Opening);
+  }
+  cover.movementStatus = closing ? Closing : Opening;
+}
+
+/**
+ * Updates the live "current position" attribute while the cover is simulating movement, on whichever cluster
+ * (WindowCovering or Closure) is currently in use.
+ *
+ * @param {Cover} cover - The cover to update.
+ * @param {number} position - The intermediate position reached so far, 0 (fully open) to 10000 (fully closed). Clamped to that range before being applied.
+ * @returns {Promise<void>}
+ */
+async function setCoverCurrentPosition(cover: Cover, position: number): Promise<void> {
+  const log = cover.bridgedDevice.log;
+  const clamped = Math.max(WC_PERCENT100THS_MIN_OPEN, Math.min(position, WC_PERCENT100THS_MAX_CLOSED));
+  if (cover.liftPanel) {
+    const currentState = cover.liftPanel.getAttribute(ClosureDimension, 'currentState', log);
+    await cover.liftPanel.setAttribute(ClosureDimension, 'currentState', { position: clamped, latch: currentState?.latch, speed: currentState?.speed }, log);
+  } else {
+    await cover.bridgedDevice.setAttribute(WindowCovering, 'currentPositionLiftPercent100ths', clamped, log);
+  }
+}
 
 /**
  * This is the standard interface for Matterbridge plugins.
@@ -84,10 +217,12 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
   ) {
     super(matterbridge, log, config);
 
-    // Verify that Matterbridge is the correct version
-    if (typeof this.verifyMatterbridgeVersion !== 'function' || !this.verifyMatterbridgeVersion('3.9.0')) {
+    // Verify that Matterbridge is the correct version. Note: useClosure additionally requires a matterbridge dev
+    // branch build with Closure device support (Application Cluster Specification § 24), since the plugin's
+    // pre-release version number alone cannot express that requirement.
+    if (typeof this.verifyMatterbridgeVersion !== 'function' || !this.verifyMatterbridgeVersion('3.10.7')) {
       throw new Error(
-        `This plugin requires Matterbridge version >= "3.9.0". Please update Matterbridge from ${this.matterbridge.matterbridgeVersion} to the latest version in the frontend.`,
+        `This plugin requires Matterbridge version >= "3.10.7". Please update Matterbridge from ${this.matterbridge.matterbridgeVersion} to the latest version in the frontend.`,
       );
     }
 
@@ -146,13 +281,12 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
     }
 
     // Set cover to target = current position and status to stopped (current position persists in the cluster)
-    for (const device of this.getDevices()) {
-      const cover = this.covers.get(device.deviceName ?? '');
-      const position = device.getAttribute(WindowCovering, 'currentPositionLiftPercent100ths', device.log);
-      cover?.bridgedDevice.log.info(
-        `Setting ${device.deviceName} target to ${CYAN}${isValidNumber(position, 0, 10000) ? position / 100 : 'unknown'} %${nf} position and status to stopped. Movement duration: ${CYAN}${cover?.movementDuration}${nf}`,
+    for (const cover of this.covers.values()) {
+      const position = getCoverPosition(cover);
+      cover.bridgedDevice.log.info(
+        `Setting ${cover.tahomaDevice.label} target to ${CYAN}${isValidNumber(position, 0, 10000) ? position / 100 : 'unknown'} %${nf} position and status to stopped. Movement duration: ${CYAN}${cover.movementDuration}${nf}`,
       );
-      await device.setWindowCoveringTargetAsCurrentAndStopped();
+      if (isValidNumber(position, 0, 10000)) await setCoverStoppedAt(cover, position);
     }
   }
 
@@ -267,15 +401,34 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
         this.log.debug(`***Tahoma update for ${device.label}: ${debugStringify(changedStates)}`);
       });
 
-      const cover = new MatterbridgeEndpoint([windowCovering, bridgedNode, powerSource], { id: device.label }, this.config.debug);
-      cover.createDefaultIdentifyClusterServer(1, Identify.IdentifyType.Actuator);
-      cover.createDefaultWindowCoveringClusterServer();
-      cover.createDefaultBridgedDeviceBasicInformationClusterServer(device.label, device.serialNumber, 0xfff1, 'Somfy Tahoma', device.definition.uiClass);
-      if (device.states.find((s) => s.name === 'core:BatteryDiscreteLevelState')) cover.createDefaultPowerSourceRechargeableBatteryClusterServer();
-      else cover.createDefaultPowerSourceWiredClusterServer();
-      cover.addRequiredClusterServers();
+      let cover: MatterbridgeEndpoint;
+      let liftPanel: MatterbridgeEndpoint | undefined;
+      if (this.config.useClosure) {
+        // Window openers (e.g. Velux roof windows) are a Closure in their own right (ClosureTag.Window), not a covering,
+        // so the ClosureCoveringTag material subtype only applies to actual coverings (blinds, shutters, awnings, ...).
+        const isWindow = device.definition.uiClass === 'Window';
+        const closureCover = new Closure(device.label, device.serialNumber, {
+          powerSourceType: device.states.find((s) => s.name === 'core:BatteryDiscreteLevelState') ? 'Rechargeable' : 'Wired',
+          tagList: isWindow ? [getSemtag(ClosureTag.Window)] : [getSemtag(ClosureTag.Covering), getSemtag(getCoveringTag(device))],
+        });
+        closureCover.createDefaultBasicInformationClusterServer(device.label, device.serialNumber, 0xfff1, 'Somfy Tahoma', 0x8000, device.definition.uiClass);
+        // Window openers open by rotating on a hinge, not by translating up/down like a shutter or blind, so their
+        // panel must advertise the Rotation feature (ClosureDimension.Feature.Rotation) via a 'tilt' panel tagged
+        // ClosurePanelTag.Tilt instead of a 'lift'/ClosurePanelTag.Lift (Translation) panel.
+        liftPanel = isWindow ? closureCover.addPanel('Tilt', [getSemtag(ClosurePanelTag.Tilt)], 'tilt') : closureCover.addPanel('Lift', [getSemtag(ClosurePanelTag.Lift)], 'lift');
+        closureCover.addRequiredClusters();
+        cover = closureCover;
+      } else {
+        cover = new MatterbridgeEndpoint([windowCovering, bridgedNode, powerSource], { id: device.label }, this.config.debug);
+        cover.createDefaultIdentifyClusterServer(1, Identify.IdentifyType.Actuator);
+        cover.createDefaultWindowCoveringClusterServer();
+        cover.createDefaultBridgedDeviceBasicInformationClusterServer(device.label, device.serialNumber, 0xfff1, 'Somfy Tahoma', device.definition.uiClass);
+        if (device.states.find((s) => s.name === 'core:BatteryDiscreteLevelState')) cover.createDefaultPowerSourceRechargeableBatteryClusterServer();
+        else cover.createDefaultPowerSourceWiredClusterServer();
+        cover.addRequiredClusterServers();
+      }
       await this.registerDevice(cover);
-      this.covers.set(device.label, { tahomaDevice: device, bridgedDevice: cover, movementStatus: Stopped, movementDuration: duration });
+      this.covers.set(device.label, { tahomaDevice: device, bridgedDevice: cover, liftPanel, movementStatus: Stopped, movementDuration: duration });
 
       cover.addCommandHandler('Identify.identify', async ({ request: { identifyTime } }) => {
         const cover = this.covers.get(device.label);
@@ -284,65 +437,122 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
         await this.sendCommand('identify', device, true);
       });
 
-      cover.addCommandHandler('WindowCovering.upOrOpen', () => {
-        const cover = this.covers.get(device.label);
-        if (!cover) return;
-        if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
-        // oxlint-disable-next-line typescript/no-misused-promises
-        cover.commandTimeout = setTimeout(async () => {
-          cover.commandTimeout = undefined;
-          cover.bridgedDevice.log.info(`Command ${ign}upOrOpen${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
-          await this.moveToPosition(cover, WC_PERCENT100THS_MIN_OPEN);
-        }, 500);
-      });
+      if (liftPanel) {
+        cover.addCommandHandler('ClosureControl.moveTo', ({ request: { position } }) => {
+          const cover = this.covers.get(device.label);
+          if (!cover) return;
+          const targetPosition =
+            position === ClosureControl.TargetPosition.MoveToFullyOpen
+              ? WC_PERCENT100THS_MIN_OPEN
+              : position === ClosureControl.TargetPosition.MoveToFullyClosed
+                ? WC_PERCENT100THS_MAX_CLOSED
+                : undefined;
+          if (targetPosition === undefined) {
+            cover.bridgedDevice.log.warn(`Command moveTo called with unsupported position:${position}`);
+            return;
+          }
+          if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
+          // oxlint-disable-next-line typescript/no-misused-promises
+          cover.commandTimeout = setTimeout(async () => {
+            cover.commandTimeout = undefined;
+            cover.bridgedDevice.log.info(`Command ${ign}moveTo${rs}${nf} ${CYAN}${targetPosition}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
+            await this.moveToPosition(cover, targetPosition);
+          }, 500);
+        });
 
-      cover.addCommandHandler('WindowCovering.downOrClose', () => {
-        const cover = this.covers.get(device.label);
-        if (!cover) return;
-        if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
-        // oxlint-disable-next-line typescript/no-misused-promises
-        cover.commandTimeout = setTimeout(async () => {
+        cover.addCommandHandler('ClosureControl.stop', async () => {
+          const cover = this.covers.get(device.label);
+          if (!cover) return;
+          cover.bridgedDevice.log.info(`Command ${ign}stop${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}. Status ${cover.movementStatus}`);
+          if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
           cover.commandTimeout = undefined;
-          cover.bridgedDevice.log.info(`Command ${ign}downOrClose${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
-          await this.moveToPosition(cover, WC_PERCENT100THS_MAX_CLOSED);
-        }, 500);
-      });
+          clearInterval(cover.moveInterval);
+          cover.moveInterval = undefined;
+          if (cover.movementStatus !== Stopped) {
+            await this.sendCommand('stop', cover.tahomaDevice, true);
+          }
+          const position = getCoverPosition(cover);
+          if (isValidNumber(position, 0, 10000)) await setCoverStoppedAt(cover, position);
+        });
 
-      cover.addCommandHandler('WindowCovering.goToLiftPercentage', ({ request: { liftPercent100thsValue } }) => {
-        const cover = this.covers.get(device.label);
-        if (!cover) return;
-        if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
-        // oxlint-disable-next-line typescript/no-misused-promises
-        cover.commandTimeout = setTimeout(async () => {
-          cover.commandTimeout = undefined;
-          cover.bridgedDevice.log.info(`Command ${ign}goToLiftPercentage${rs}${nf} ${CYAN}${liftPercent100thsValue}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
-          await this.moveToPosition(cover, liftPercent100thsValue);
-        }, 500);
-      });
+        liftPanel.addCommandHandler('ClosureDimension.setTarget', ({ request: { position } }) => {
+          const cover = this.covers.get(device.label);
+          if (!cover) return;
+          if (!isValidNumber(position, 0, 10000)) {
+            cover.bridgedDevice.log.warn(`Command setTarget called with unsupported position:${position}`);
+            return;
+          }
+          if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
+          // oxlint-disable-next-line typescript/no-misused-promises
+          cover.commandTimeout = setTimeout(async () => {
+            cover.commandTimeout = undefined;
+            cover.bridgedDevice.log.info(`Command ${ign}setTarget${rs}${nf} ${CYAN}${position}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
+            await this.moveToPosition(cover, position);
+          }, 500);
+        });
+      } else {
+        cover.addCommandHandler('WindowCovering.upOrOpen', () => {
+          const cover = this.covers.get(device.label);
+          if (!cover) return;
+          if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
+          // oxlint-disable-next-line typescript/no-misused-promises
+          cover.commandTimeout = setTimeout(async () => {
+            cover.commandTimeout = undefined;
+            cover.bridgedDevice.log.info(`Command ${ign}upOrOpen${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
+            await this.moveToPosition(cover, WC_PERCENT100THS_MIN_OPEN);
+          }, 500);
+        });
 
-      cover.addCommandHandler('WindowCovering.stopMotion', async ({ attributes }) => {
-        attributes.targetPositionLiftPercent100ths = attributes.currentPositionLiftPercent100ths;
-        attributes.operationalStatus = {
-          global: WindowCovering.MovementStatus.Stopped,
-          lift: WindowCovering.MovementStatus.Stopped,
-          tilt: WindowCovering.MovementStatus.Stopped,
-        };
-        const cover = this.covers.get(device.label);
-        if (!cover) return;
-        cover.bridgedDevice.log.info(`Command ${ign}stopMotion${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}. Status ${cover.movementStatus}`);
-        clearInterval(cover.moveInterval);
-        if (cover.movementStatus !== WindowCovering.MovementStatus.Stopped) {
-          await this.sendCommand('stop', cover.tahomaDevice, true);
-        }
-        cover.movementStatus = Stopped;
-      });
+        cover.addCommandHandler('WindowCovering.downOrClose', () => {
+          const cover = this.covers.get(device.label);
+          if (!cover) return;
+          if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
+          // oxlint-disable-next-line typescript/no-misused-promises
+          cover.commandTimeout = setTimeout(async () => {
+            cover.commandTimeout = undefined;
+            cover.bridgedDevice.log.info(`Command ${ign}downOrClose${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
+            await this.moveToPosition(cover, WC_PERCENT100THS_MAX_CLOSED);
+          }, 500);
+        });
+
+        cover.addCommandHandler('WindowCovering.goToLiftPercentage', ({ request: { liftPercent100thsValue } }) => {
+          const cover = this.covers.get(device.label);
+          if (!cover) return;
+          if (cover.commandTimeout) clearTimeout(cover.commandTimeout);
+          // oxlint-disable-next-line typescript/no-misused-promises
+          cover.commandTimeout = setTimeout(async () => {
+            cover.commandTimeout = undefined;
+            cover.bridgedDevice.log.info(`Command ${ign}goToLiftPercentage${rs}${nf} ${CYAN}${liftPercent100thsValue}${nf} called for ${CYAN}${cover.tahomaDevice.label}`);
+            await this.moveToPosition(cover, liftPercent100thsValue);
+          }, 500);
+        });
+
+        cover.addCommandHandler('WindowCovering.stopMotion', async ({ attributes }) => {
+          attributes.targetPositionLiftPercent100ths = attributes.currentPositionLiftPercent100ths;
+          attributes.operationalStatus = {
+            global: WindowCovering.MovementStatus.Stopped,
+            lift: WindowCovering.MovementStatus.Stopped,
+            tilt: WindowCovering.MovementStatus.Stopped,
+          };
+          const cover = this.covers.get(device.label);
+          if (!cover) return;
+          cover.bridgedDevice.log.info(`Command ${ign}stopMotion${rs}${nf} called for ${CYAN}${cover.tahomaDevice.label}. Status ${cover.movementStatus}`);
+          clearInterval(cover.moveInterval);
+          if (cover.movementStatus !== WindowCovering.MovementStatus.Stopped) {
+            await this.sendCommand('stop', cover.tahomaDevice, true);
+          }
+          cover.movementStatus = Stopped;
+        });
+      }
     }
   }
 
-  // With Matter 0=open 10000=close
+  // With Matter 0=open 10000=close. Cluster-agnostic: reads/writes go through getCoverPosition/setCoverStoppedAt/
+  // setCoverMoving/setCoverCurrentPosition, which branch on cover.liftPanel to target either the WindowCovering
+  // cluster or the Closure/ClosureDimension clusters (see the useClosure config option).
   async moveToPosition(cover: Cover, targetPosition: number): Promise<void> {
     const log = cover.bridgedDevice.log;
-    const position = cover.bridgedDevice.getAttribute(WindowCovering, 'currentPositionLiftPercent100ths', log);
+    const position = getCoverPosition(cover);
     if (!isValidNumber(position, 0, 10000)) return;
     let currentPosition = position;
     log.info(`Moving from ${currentPosition} to ${targetPosition}...`);
@@ -352,17 +562,15 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
       log.info('Stopping current movement.');
       clearInterval(cover.moveInterval);
       cover.moveInterval = undefined;
-      await cover.bridgedDevice.setWindowCoveringTargetAsCurrentAndStopped();
+      await setCoverStoppedAt(cover, currentPosition);
       await this.sendCommand('stop', cover.tahomaDevice, true);
-      cover.movementStatus = Stopped;
       return;
     }
     // Return if already at target position
     if (targetPosition === currentPosition) {
       clearInterval(cover.moveInterval);
       cover.moveInterval = undefined;
-      await cover.bridgedDevice.setWindowCoveringTargetAsCurrentAndStopped();
-      cover.movementStatus = Stopped;
+      await setCoverStoppedAt(cover, currentPosition);
       log.info(`Moving from ${currentPosition} to ${targetPosition}. No movement needed.`);
       return;
     }
@@ -370,9 +578,7 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
     const movement = targetPosition - currentPosition;
     const movementSeconds = Math.abs((movement * cover.movementDuration) / 10000);
     log.debug(`Moving from ${currentPosition} to ${targetPosition} in ${movementSeconds} seconds. Movement requested ${movement}`);
-    await cover.bridgedDevice.setAttribute(WindowCovering, 'targetPositionLiftPercent100ths', targetPosition, log);
-    await cover.bridgedDevice.setWindowCoveringStatus(targetPosition > currentPosition ? WindowCovering.MovementStatus.Closing : WindowCovering.MovementStatus.Opening);
-    cover.movementStatus = targetPosition > currentPosition ? Closing : Opening;
+    await setCoverMoving(cover, targetPosition, targetPosition > currentPosition);
     await this.sendCommand(targetPosition > currentPosition ? 'close' : 'open', cover.tahomaDevice, true);
 
     // oxlint-disable-next-line typescript/no-misused-promises
@@ -382,18 +588,12 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
       currentPosition = Math.round(currentPosition + movement / movementSeconds);
       if (Math.abs(targetPosition - currentPosition) <= 100 || (movement > 0 && currentPosition >= targetPosition) || (movement < 0 && currentPosition <= targetPosition)) {
         clearInterval(cover.moveInterval);
-        await cover.bridgedDevice.setWindowCoveringCurrentTargetStatus(targetPosition, targetPosition, WindowCovering.MovementStatus.Stopped);
-        cover.movementStatus = Stopped;
+        await setCoverStoppedAt(cover, targetPosition);
         if (targetPosition !== WC_PERCENT100THS_MIN_OPEN && targetPosition !== WC_PERCENT100THS_MAX_CLOSED) await this.sendCommand('stop', cover.tahomaDevice, true);
         log.debug(`Moving stopped at ${targetPosition}`);
       } else {
         log.debug(`Moving from ${currentPosition} to ${targetPosition} difference ${Math.abs(targetPosition - currentPosition)}`);
-        await cover.bridgedDevice.setAttribute(
-          WindowCovering,
-          'currentPositionLiftPercent100ths',
-          Math.max(WC_PERCENT100THS_MIN_OPEN, Math.min(currentPosition, WC_PERCENT100THS_MAX_CLOSED)),
-          log,
-        );
+        await setCoverCurrentPosition(cover, currentPosition);
       }
     }, 1000);
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -433,10 +433,7 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
         // Window openers (e.g. Velux roof windows) are a Closure in their own right (ClosureTag.Window), not a covering,
         // so the ClosureCoveringTag material subtype only applies to actual coverings (blinds, shutters, awnings, ...).
         const isWindow = device.definition.uiClass === 'Window';
-        const closureCover = new Closure(device.label, device.serialNumber, {
-          powerSourceType: device.states.find((s) => s.name === 'core:BatteryDiscreteLevelState') ? 'Rechargeable' : 'Wired',
-          tagList: isWindow ? [getSemtag(ClosureTag.Window)] : [getSemtag(ClosureTag.Covering), getSemtag(getCoveringTag(device))],
-          calibration: this.config.closureCalibration?.[device.label],
+          tagList: isWindow ? [getSemtag(ClosureTag.Window)] : [getSemtag(ClosureTag.Covering), getCoveringTag(device)],
           ventilation: this.config.closureVentilation?.[device.label],
           pedestrian: this.config.closurePedestrian?.[device.label],
         });

--- a/src/module.ts
+++ b/src/module.ts
@@ -82,9 +82,9 @@ export type SomfyTahomaPlatformConfig = PlatformConfig & {
  * the Closure endpoint (Application Cluster Specification § 24, ClosureCoveringTag namespace).
  *
  * @param {Device} device - The discovered TaHoma device.
- * @returns {typeof ClosureCoveringTag.Shutter} The semantic tag describing the covering type.
+ * @returns {Semtag} The semantic tag describing the covering type: Venetian, Awning, Blind, or Shutter (the fallback for Shutter, RollerShutter, and any other supported uiClass).
  */
-function getCoveringTag(device: Device): typeof ClosureCoveringTag.Shutter {
+function getCoveringTag(device: Device): ReturnType<typeof getSemtag> {
   const uiClass = device.definition.uiClass;
   if (uiClass === 'VenetianBlind' || uiClass === 'ExteriorVenetianBlind') return ClosureCoveringTag.Venetian;
   if (uiClass === 'Awning' || uiClass === 'Pergola') return ClosureCoveringTag.Awning;
@@ -149,6 +149,25 @@ async function setCoverStoppedAt(cover: Cover, position: number): Promise<void> 
     );
   } else {
     await cover.bridgedDevice.setWindowCoveringCurrentTargetStatus(position, position, WindowCovering.MovementStatus.Stopped);
+  }
+  cover.movementStatus = Stopped;
+}
+
+/**
+ * Marks the cover stopped without touching its current/target position attributes, on whichever cluster
+ * (WindowCovering or Closure) is currently in use. Use this instead of `setCoverStoppedAt` when the current
+ * position is not known (null/undefined), so the movement status still leaves the "moving" state. Updates
+ * `cover.movementStatus`.
+ *
+ * @param {Cover} cover - The cover to update.
+ * @returns {Promise<void>}
+ */
+async function setCoverStopped(cover: Cover): Promise<void> {
+  const log = cover.bridgedDevice.log;
+  if (cover.liftPanel) {
+    await cover.bridgedDevice.setAttribute(ClosureControl, 'mainState', ClosureControl.MainState.Stopped, log);
+  } else {
+    await cover.bridgedDevice.setWindowCoveringStatus(WindowCovering.MovementStatus.Stopped);
   }
   cover.movementStatus = Stopped;
 }
@@ -293,6 +312,7 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
         `Setting ${cover.tahomaDevice.label} target to ${CYAN}${isValidNumber(position, 0, 10000) ? position / 100 : 'unknown'} %${nf} position and status to stopped. Movement duration: ${CYAN}${cover.movementDuration}${nf}`,
       );
       if (isValidNumber(position, 0, 10000)) await setCoverStoppedAt(cover, position);
+      else await setCoverStopped(cover);
     }
   }
 
@@ -482,6 +502,7 @@ export class SomfyTahomaPlatform extends MatterbridgeDynamicPlatform {
           }
           const position = getCoverPosition(cover);
           if (isValidNumber(position, 0, 10000)) await setCoverStoppedAt(cover, position);
+          else await setCoverStopped(cover);
         });
 
         liftPanel.addCommandHandler('ClosureDimension.setTarget', ({ request: { position } }) => {

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -412,6 +412,31 @@ describe('SomfyTahomaPlatform', () => {
     expect(cover.moveInterval).toBeUndefined();
   });
 
+  it('should mark a Closure stopped without syncing position when ClosureControl.stop is called and the position is unknown', async () => {
+    const cover = somfyPlatform.covers.get('Device1');
+    expect(cover).toBeDefined();
+    if (!cover) return;
+    const device = cover.bridgedDevice;
+    const liftPanel = cover.liftPanel;
+    expect(liftPanel).toBeDefined();
+    if (!liftPanel) return;
+
+    cover.movementStatus = WindowCovering.MovementStatus.Opening;
+    cover.moveInterval = setInterval(() => {
+      // noop
+    }, 1000);
+    // Simulate an unknown current position (e.g. right after startup, before the panel reports a value)
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- explicit undefined is required to match getAttribute's overload
+    vi.spyOn(liftPanel, 'getAttribute').mockReturnValueOnce(undefined);
+
+    await device.executeCommandHandler('ClosureControl.stop', {}, 'closureControl', (device.state as any).closureControl, device);
+
+    expect(clientExecuteSpy).toHaveBeenCalledWith('apply/highPriority', expect.anything());
+    // movementStatus and mainState still leave the "moving" state even though the position could not be synced
+    expect(cover.movementStatus).toBe(WindowCovering.MovementStatus.Stopped);
+    expect(device.getAttribute(ClosureControl.id, 'mainState')).toBe(ClosureControl.MainState.Stopped);
+  });
+
   it('should send stop on ClosureControl.stop when movementStatus is not stopped', async () => {
     const cover = somfyPlatform.covers.get('Device1');
     expect(cover).toBeDefined();
@@ -640,6 +665,29 @@ describe('SomfyTahomaPlatform', () => {
   it('should call onConfigure', async () => {
     await somfyPlatform.onConfigure();
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onConfigure called');
+  });
+
+  it('should mark a WindowCovering cover stopped without syncing position when onConfigure runs and the position is unknown', async () => {
+    const cover = somfyPlatform.covers.get('Device1');
+    expect(cover).toBeDefined();
+    if (!cover) return;
+    const device = cover.bridgedDevice;
+
+    cover.movementStatus = WindowCovering.MovementStatus.Opening;
+    // Simulate an unknown current position (e.g. right after startup, before the cluster reports a value)
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- explicit undefined is required to match getAttribute's overload
+    vi.spyOn(device, 'getAttribute').mockReturnValueOnce(undefined);
+
+    await somfyPlatform.onConfigure();
+
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onConfigure called');
+    // movementStatus and operationalStatus still leave the "moving" state even though the position could not be synced
+    expect(cover.movementStatus).toBe(WindowCovering.MovementStatus.Stopped);
+    expect(device.getAttribute(WindowCovering.id, 'operationalStatus')).toEqual({
+      global: WindowCovering.MovementStatus.Stopped,
+      lift: WindowCovering.MovementStatus.Stopped,
+      tilt: WindowCovering.MovementStatus.Stopped,
+    });
   });
 
   it('should call onConfigure and log error', async () => {

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -13,7 +13,8 @@ import { promises as fs } from 'node:fs';
 
 import type { PlatformMatterbridge } from 'matterbridge';
 import { BLUE, CYAN, ign, LogLevel, nf, rs, YELLOW } from 'matterbridge/logger';
-import { WindowCovering } from 'matterbridge/matter/clusters';
+import { ClosureCoveringTag, ClosurePanelTag, ClosureTag } from 'matterbridge/matter';
+import { ClosureControl, ClosureDimension, WindowCovering } from 'matterbridge/matter/clusters';
 import { wait } from 'matterbridge/utils';
 import { flushAsync, log, loggerLogSpy, setDebug, setupTest } from 'matterbridge/vitest-utils';
 import {
@@ -162,7 +163,7 @@ describe('SomfyTahomaPlatform', () => {
   });
 
   it('should throw because of version', () => {
-    expect(() => new SomfyTahomaPlatform({ ...matterbridge, matterbridgeVersion: '3.8.0' }, log, config)).toThrow('This plugin requires Matterbridge version >= "3.9.0".');
+    expect(() => new SomfyTahomaPlatform({ ...matterbridge, matterbridgeVersion: '3.8.0' }, log, config)).toThrow('This plugin requires Matterbridge version >= "3.10.7".');
   });
 
   it('should call onStart with reason', async () => {
@@ -263,6 +264,159 @@ describe('SomfyTahomaPlatform', () => {
     await somfyPlatform.unregisterAllDevices();
     expect(aggregator.parts.size).toBe(0);
     await flushAsync();
+  });
+
+  it('should tag a Window uiClass device with ClosureTag.Window and a rotating Tilt panel when useClosure is enabled', async () => {
+    somfyPlatform.config.useClosure = true;
+    setMockDevice({ label: 'Device1', uniqueName: 'WindowOpenerVeluxIOComponent', uiClass: 'Window', commands: ['open', 'close', 'stop'] });
+    clientGetDevicesSpy.mockResolvedValueOnce(mockDevices);
+    await somfyPlatform.discoverDevices();
+    const cover = somfyPlatform.covers.get('Device1');
+    expect(cover?.bridgedDevice.tagList).toEqual([{ mfgCode: null, namespaceId: ClosureTag.Window.namespaceId, tag: ClosureTag.Window.tag }]);
+    expect(cover?.liftPanel?.tagList).toEqual([{ mfgCode: null, namespaceId: ClosurePanelTag.Tilt.namespaceId, tag: ClosurePanelTag.Tilt.tag }]);
+    // A rotating window opener supports the Rotation feature (rotationAxis attribute), not Translation (translationDirection attribute)
+    expect(cover?.liftPanel?.hasAttributeServer(ClosureDimension, 'rotationAxis')).toBe(true);
+    expect(cover?.liftPanel?.hasAttributeServer(ClosureDimension, 'translationDirection')).toBe(false);
+
+    somfyPlatform.tahomaDevices = [];
+    somfyPlatform.covers.clear();
+    await somfyPlatform.unregisterAllDevices();
+    expect(aggregator.parts.size).toBe(0);
+    await flushAsync();
+    somfyPlatform.config.useClosure = false;
+  });
+
+  it('should tag a Shutter uiClass device with ClosureCoveringTag.Shutter when useClosure is enabled', async () => {
+    somfyPlatform.config.useClosure = true;
+    setMockDevice({ label: 'Device1', uniqueName: 'xxx', uiClass: 'Shutter' });
+    clientGetDevicesSpy.mockResolvedValueOnce(mockDevices);
+    await somfyPlatform.discoverDevices();
+    const cover = somfyPlatform.covers.get('Device1');
+    expect(cover?.bridgedDevice.tagList).toEqual([
+      { mfgCode: null, namespaceId: ClosureTag.Covering.namespaceId, tag: ClosureTag.Covering.tag },
+      { mfgCode: null, namespaceId: ClosureCoveringTag.Shutter.namespaceId, tag: ClosureCoveringTag.Shutter.tag },
+    ]);
+
+    somfyPlatform.tahomaDevices = [];
+    somfyPlatform.covers.clear();
+    await somfyPlatform.unregisterAllDevices();
+    expect(aggregator.parts.size).toBe(0);
+    await flushAsync();
+    somfyPlatform.config.useClosure = false;
+  });
+
+  it('should discover a Closure cover with a battery power source and handle a full moveTo/setTarget/stop cycle', async () => {
+    somfyPlatform.config.useClosure = true;
+    setMockDevice({ label: 'Device1', uniqueName: 'Blind' });
+    mockDevices[0].states = [{ name: 'core:BatteryDiscreteLevelState', type: 3, value: 'normal' } satisfies State];
+    clientGetDevicesSpy.mockResolvedValueOnce(mockDevices);
+    await somfyPlatform.discoverDevices();
+    expect(somfyPlatform.covers.size).toBe(1);
+
+    const cover = somfyPlatform.covers.get('Device1');
+    expect(cover).toBeDefined();
+    if (!cover) return;
+    const device = cover.bridgedDevice;
+    const liftPanel = cover.liftPanel;
+    expect(liftPanel).toBeDefined();
+    if (!liftPanel) return;
+    // uiClass defaults to 'Screen' (see createMockDevice), which maps to ClosureCoveringTag.Blind
+    expect(cover.bridgedDevice.tagList).toEqual([
+      { mfgCode: null, namespaceId: ClosureTag.Covering.namespaceId, tag: ClosureTag.Covering.tag },
+      { mfgCode: null, namespaceId: ClosureCoveringTag.Blind.namespaceId, tag: ClosureCoveringTag.Blind.tag },
+    ]);
+    expect(liftPanel.tagList).toEqual([{ mfgCode: null, namespaceId: ClosurePanelTag.Lift.namespaceId, tag: ClosurePanelTag.Lift.tag }]);
+    // A battery powered device restores the same Rechargeable power source parity as the WindowCovering path
+    expect(device.hasAttributeServer('PowerSource', 'batPercentRemaining')).toBe(true);
+    // The Lift panel starts fully open (position 0), matching the WindowCovering path's default
+    expect(liftPanel.getAttribute(ClosureDimension.id, 'currentState')?.position).toBe(WC_PERCENT100THS_MIN_OPEN);
+
+    vi.clearAllMocks();
+    await device.executeCommandHandler('Identify.identify', { identifyTime: 1 }, 'identify', (device.state as any).identify, device);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}identify${rs}${nf} called identifyTime:1`);
+
+    vi.clearAllMocks();
+    await device.executeCommandHandler(
+      'ClosureControl.moveTo',
+      { position: ClosureControl.TargetPosition.MoveToPedestrianPosition },
+      'closureControl',
+      (device.state as any).closureControl,
+      device,
+    );
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.WARN, `Command moveTo called with unsupported position:${ClosureControl.TargetPosition.MoveToPedestrianPosition}`);
+
+    vi.clearAllMocks();
+    await device.executeCommandHandler(
+      'ClosureControl.moveTo',
+      { position: ClosureControl.TargetPosition.MoveToFullyClosed },
+      'closureControl',
+      (device.state as any).closureControl,
+      device,
+    );
+    await wait(3000);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}moveTo${rs}${nf} ${CYAN}${WC_PERCENT100THS_MAX_CLOSED}${nf} called for ${CYAN}${mockDevices[0].label}`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, `Moving stopped at ${WC_PERCENT100THS_MAX_CLOSED}`);
+    expect(liftPanel.getAttribute(ClosureDimension.id, 'currentState')?.position).toBe(WC_PERCENT100THS_MAX_CLOSED);
+
+    vi.clearAllMocks();
+    await liftPanel.executeCommandHandler('ClosureDimension.setTarget', { position: 5000 }, 'closureDimension', (liftPanel.state as any).closureDimension, liftPanel);
+    await wait(3000);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Command ${ign}setTarget${rs}${nf} ${CYAN}5000${nf} called for ${CYAN}${mockDevices[0].label}`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, `Moving stopped at 5000`);
+    expect(liftPanel.getAttribute(ClosureDimension.id, 'currentState')?.position).toBe(5000);
+
+    vi.clearAllMocks();
+    await liftPanel.executeCommandHandler('ClosureDimension.setTarget', { position: 100000 }, 'closureDimension', (liftPanel.state as any).closureDimension, liftPanel);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.WARN, `Command setTarget called with unsupported position:100000`);
+
+    // We keep this Closure device to be used in the next tests
+  }, 120000);
+
+  it('should stop current movement in moveToPosition when already moving (Closure)', async () => {
+    const cover = somfyPlatform.covers.get('Device1');
+    expect(cover).toBeDefined();
+    if (!cover) return;
+
+    cover.movementStatus = WindowCovering.MovementStatus.Opening;
+    cover.moveInterval = setInterval(() => {
+      // noop
+    }, 1000);
+
+    await somfyPlatform.moveToPosition(cover, 8000);
+
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'Stopping current movement.');
+    expect(clientExecuteSpy).toHaveBeenCalledWith('apply/highPriority', expect.anything());
+    expect(cover.movementStatus).toBe(WindowCovering.MovementStatus.Stopped);
+    expect(cover.moveInterval).toBeUndefined();
+  });
+
+  it('should send stop on ClosureControl.stop when movementStatus is not stopped', async () => {
+    const cover = somfyPlatform.covers.get('Device1');
+    expect(cover).toBeDefined();
+    if (!cover) return;
+    const device = cover.bridgedDevice;
+
+    cover.movementStatus = WindowCovering.MovementStatus.Opening;
+    cover.moveInterval = setInterval(() => {
+      // noop
+    }, 1000);
+
+    await device.executeCommandHandler('ClosureControl.stop', {}, 'closureControl', (device.state as any).closureControl, device);
+
+    expect(clientExecuteSpy).toHaveBeenCalledWith('apply/highPriority', expect.anything());
+    expect(cover.movementStatus).toBe(WindowCovering.MovementStatus.Stopped);
+
+    // Calling stop again while already stopped must not send another stop command
+    vi.clearAllMocks();
+    await device.executeCommandHandler('ClosureControl.stop', {}, 'closureControl', (device.state as any).closureControl, device);
+    expect(clientExecuteSpy).not.toHaveBeenCalled();
+
+    somfyPlatform.tahomaDevices = [];
+    somfyPlatform.covers.clear();
+    await somfyPlatform.unregisterAllDevices();
+    expect(aggregator.parts.size).toBe(0);
+    await flushAsync();
+    somfyPlatform.config.useClosure = false;
   });
 
   it('should add a rechargeable battery cover and handle device state updates', async () => {

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -305,6 +305,28 @@ describe('SomfyTahomaPlatform', () => {
     somfyPlatform.config.useClosure = false;
   });
 
+  it('should opt in per device to the Closure Calibration, Ventilation and Pedestrian optional features when useClosure is enabled', async () => {
+    somfyPlatform.config.useClosure = true;
+    somfyPlatform.config.closureCalibration = { Device1: true };
+    somfyPlatform.config.closureVentilation = { Device1: true };
+    somfyPlatform.config.closurePedestrian = { Device1: true };
+    setMockDevice({ label: 'Device1', uniqueName: 'xxx', uiClass: 'Shutter' });
+    clientGetDevicesSpy.mockResolvedValueOnce(mockDevices);
+    await somfyPlatform.discoverDevices();
+    const cover = somfyPlatform.covers.get('Device1');
+    expect(cover?.bridgedDevice.getAttribute(ClosureControl.id, 'featureMap')).toEqual(expect.objectContaining({ calibration: true, ventilation: true, pedestrian: true }));
+
+    somfyPlatform.tahomaDevices = [];
+    somfyPlatform.covers.clear();
+    await somfyPlatform.unregisterAllDevices();
+    expect(aggregator.parts.size).toBe(0);
+    await flushAsync();
+    somfyPlatform.config.useClosure = false;
+    somfyPlatform.config.closureCalibration = undefined;
+    somfyPlatform.config.closureVentilation = undefined;
+    somfyPlatform.config.closurePedestrian = undefined;
+  });
+
   it('should discover a Closure cover with a battery power source and handle a full moveTo/setTarget/stop cycle', async () => {
     somfyPlatform.config.useClosure = true;
     setMockDevice({ label: 'Device1', uniqueName: 'Blind' });


### PR DESCRIPTION
## Summary

Resumes the approach prototyped in #46 (migrating Somfy covers to the Matter 1.5 `Closure` device type), but as an **opt-in `useClosure` config flag** (default `false`) instead of a hard replacement, so existing installs keep the current `WindowCovering` behavior unless they explicitly opt in for integration testing with controllers that support the newer cluster.

## What changed

- New `useClosure` platform config option (schema + sample config + README).
- When enabled, covers are built with the matterbridge **dev branch**'s `Closure` device class (`Closure`/`ClosureControl`/`ClosureDimension`, tagged via `ClosureTag`/`ClosureCoveringTag`/`ClosurePanelTag`), with a `Lift` panel for regular coverings and a rotating `Tilt` panel for `Window` (e.g. Velux) uiClass devices.
- Uses the `Closure` class's `powerSourceType` constructor option and `setState()` helper (added to matterbridge's dev branch after #46 was opened) to restore battery/wired PowerSource parity that #46 had to drop, and to simplify the `overallCurrentState` bookkeeping.
- Extracted `getCoverPosition` / `setCoverStoppedAt` / `setCoverMoving` / `setCoverCurrentPosition` as small cluster-agnostic helpers so `moveToPosition`'s movement-timer state machine is shared, unchanged, between the `WindowCovering` and `Closure` code paths — the default (disabled) path is otherwise untouched.
- `onConfigure` now iterates `this.covers.values()` directly instead of going through `getDevices()` + name lookup, for both device types.
- **Breaking change**: bumps the required matterbridge version to `3.10.7`. `useClosure` specifically requires a matterbridge **dev branch** build with `Closure` device support (not yet in a stable release), documented in the README/CHANGELOG.
- Tests: added coverage for the `useClosure` path (Window tagging + Tilt/Rotation panel, Shutter tagging, battery-powered Closure device, full moveTo/setTarget/stop cycle, stop-while-moving) — 100% lines/functions maintained.

## Testing

- `npm run build`, `npm run typecheck`, `npm run lint`, `npm run format:check` all pass.
- `npm run test:coverage` passes with 100% lines/functions (30 tests).


